### PR TITLE
Add live Dublin Airport weather defaults

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -64,3 +64,10 @@ h1 {
             background-size: cover;
             background-position: center;
         }
+
+.loading-message {
+    font-size: 0.9em;
+    margin-bottom: 10px;
+    font-style: italic;
+    color: #333;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,9 @@
 
     <div class="form-wrapper">
         <h1>Water Activity GO/NO GO</h1>
+        <div id="loading-message" class="loading-message" style="display:none;">
+            Loading latest weather data from Dublin Airport...
+        </div>
         <form method="post" class="input-form">
             <label for="location">Location:</label>
             <select name="location" id="location">
@@ -27,7 +30,7 @@
             </select><br>
 
             <label for="distance">Distance from shore (m):</label>
-            <input type="number" step="1" min="0" name="distance" id="distance" required><br>
+            <input type="number" step="1" min="0" name="distance" id="distance" value="{{ default_distance }}" required><br>
 
             <label for="wind_speed">Wind speed (km/h):</label>
             <input type="number" step="0.1" name="wind_speed" id="wind_speed" required><br>
@@ -37,13 +40,13 @@
             <br>
 
             <label for="solo_participants">Solo craft participants:</label>
-            <input type="number" min="0" name="solo_participants" id="solo_participants" value="0" required><br>
+            <input type="number" min="0" name="solo_participants" id="solo_participants" value="{{ default_solo }}" required><br>
 
             <label for="crew_participants">Crew craft participants:</label>
-            <input type="number" min="0" name="crew_participants" id="crew_participants" value="0" required><br>
+            <input type="number" min="0" name="crew_participants" id="crew_participants" value="{{ default_crew }}" required><br>
 
             <label for="coaches">Qualified coaches/leaders:</label>
-            <input type="number" min="0" name="coaches" id="coaches" value="0" required><br>
+            <input type="number" min="0" name="coaches" id="coaches" value="{{ default_coaches }}" required><br>
 
             <button type="submit">Check</button>
         </form>
@@ -108,6 +111,31 @@
         // Initialize on load
         updateBackground();
         updateWindArrow();
+
+        window.addEventListener('DOMContentLoaded', () => {
+            const loading = document.getElementById('loading-message');
+            loading.style.display = 'block';
+            fetch('/wind')
+                .then(r => r.json())
+                .then(data => {
+                    if (!data.error) {
+                        windSpeedInput.value = data.speed;
+                        windDirInput.value = data.direction;
+                    } else {
+                        loading.textContent = 'Could not load weather data.';
+                    }
+                    updateWindArrow();
+                })
+                .catch(() => {
+                    loading.textContent = 'Could not load weather data.';
+                })
+                .finally(() => {
+                    setTimeout(() => {
+                        loading.style.display = 'none';
+                        document.querySelector('.input-form').submit();
+                    }, 500);
+                });
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fetch latest wind info from Dublin Airport
- expose `/wind` endpoint returning the data as JSON
- prefill form defaults and show a loading message while fetching
- auto-submit the form after loading so users see results immediately

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from app import app
with app.test_client() as c:
    resp = c.get('/wind')
    print('status', resp.status_code)
    print(resp.json)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68528a405a748323905b138f110712d6