### PR TITLE
Fix endless reload when fetching weather data

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -113,6 +113,7 @@
         updateWindArrow();
 
         window.addEventListener('DOMContentLoaded', () => {
+            {% if not decision %}
             const loading = document.getElementById('loading-message');
             loading.style.display = 'block';
             fetch('/wind')
@@ -135,6 +136,7 @@
                         document.querySelector('.input-form').submit();
                     }, 500);
                 });
+            {% endif %}
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- fix refresh loop by only auto-submitting when no decision is present

## Testing
- `python -m py_compile app.py`
- `pip install flask`
- `pip install requests`
- `python app.py` *(fails: ModuleNotFoundError -> flask; after installing packages it runs)*

------
https://chatgpt.com/codex/tasks/task_e_68528c9b482c8323b375e37a0a7b69d9