### PR TITLE
Improve form persistence and UI feedback

### DIFF
--- a/app.py
+++ b/app.py
@@ -159,19 +159,38 @@ def index():
     decision_class = ''
     reasons = []
 
+    # Default values for the form fields
+    form_data = {
+        'location': next(iter(LOCATIONS.keys())),
+        'environment': next(iter(CONDITIONS.keys())),
+        'distance': 50,
+        'wind_speed': '',
+        'wind_direction': '',
+        'solo_participants': 6,
+        'crew_participants': 0,
+        'coaches': 0,
+    }
+
     if request.method == 'POST':
-        loc = request.form.get('location')
-        env = request.form.get('environment')
-        distance = float(request.form.get('distance', 0))
-        wind_speed = float(request.form.get('wind_speed', 0))
-        wind_direction = float(request.form.get('wind_direction', 0))
-        solo_participants = int(request.form.get('solo_participants', 0))
-        crew_participants = int(request.form.get('crew_participants', 0))
-        coaches = int(request.form.get('coaches', 0))
+        # Preserve submitted values
+        form_data['location'] = request.form.get('location', form_data['location'])
+        form_data['environment'] = request.form.get('environment', form_data['environment'])
+        form_data['distance'] = request.form.get('distance', form_data['distance'])
+        form_data['wind_speed'] = request.form.get('wind_speed', form_data['wind_speed'])
+        form_data['wind_direction'] = request.form.get('wind_direction', form_data['wind_direction'])
+        form_data['solo_participants'] = request.form.get('solo_participants', form_data['solo_participants'])
+        form_data['crew_participants'] = request.form.get('crew_participants', form_data['crew_participants'])
+        form_data['coaches'] = request.form.get('coaches', form_data['coaches'])
 
         decision, reasons = evaluate(
-            loc, env, distance, wind_speed, wind_direction,
-            solo_participants, crew_participants, coaches)
+            form_data['location'],
+            form_data['environment'],
+            float(form_data['distance'] or 0),
+            float(form_data['wind_speed'] or 0),
+            float(form_data['wind_direction'] or 0),
+            int(form_data['solo_participants'] or 0),
+            int(form_data['crew_participants'] or 0),
+            int(form_data['coaches'] or 0))
         decision_class = 'status-go' if decision == 'GO' else 'status-nogo'
 
     return render_template(
@@ -181,10 +200,7 @@ def index():
         decision=decision,
         decision_class=decision_class,
         reasons=reasons,
-        default_distance=50,
-        default_solo=6,
-        default_crew=0,
-        default_coaches=0)
+        form_data=form_data)
 
 
 @app.route('/wind')

--- a/static/styles.css
+++ b/static/styles.css
@@ -35,6 +35,7 @@ h1 {
 .reasons {
     list-style-type: none;
     padding: 0;
+    max-width: 100%;
 }
 
 .reasons li {
@@ -46,6 +47,8 @@ h1 {
     background-color: rgba(255, 255, 255, 0.8);
     padding: 20px;
     border-radius: 8px;
+    max-width: 500px;
+    word-wrap: break-word;
 }
 
 #wind-arrow {

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,35 +18,35 @@
             <label for="location">Location:</label>
             <select name="location" id="location">
                 {% for loc in locations %}
-                <option value="{{ loc }}">{{ loc }}</option>
+                <option value="{{ loc }}" {% if loc == form_data.location %}selected{% endif %}>{{ loc }}</option>
                 {% endfor %}
             </select><br>
 
             <label for="environment">Environment:</label>
             <select name="environment" id="environment">
                 {% for env in environments %}
-                <option value="{{ env }}">{{ env }}</option>
+                <option value="{{ env }}" {% if env == form_data.environment %}selected{% endif %}>{{ env }}</option>
                 {% endfor %}
             </select><br>
 
             <label for="distance">Distance from shore (m):</label>
-            <input type="number" step="1" min="0" name="distance" id="distance" value="{{ default_distance }}" required><br>
+            <input type="number" step="1" min="0" name="distance" id="distance" value="{{ form_data.distance }}" required><br>
 
             <label for="wind_speed">Wind speed (km/h):</label>
-            <input type="number" step="0.1" name="wind_speed" id="wind_speed" required><br>
+            <input type="number" step="0.1" name="wind_speed" id="wind_speed" value="{{ form_data.wind_speed }}" required><br>
 
             <label for="wind_direction">Wind direction (deg):</label>
-            <input type="number" step="1" min="0" max="360" name="wind_direction" id="wind_direction" required>
+            <input type="number" step="1" min="0" max="360" name="wind_direction" id="wind_direction" value="{{ form_data.wind_direction }}" required>
             <br>
 
             <label for="solo_participants">Solo craft participants:</label>
-            <input type="number" min="0" name="solo_participants" id="solo_participants" value="{{ default_solo }}" required><br>
+            <input type="number" min="0" name="solo_participants" id="solo_participants" value="{{ form_data.solo_participants }}" required><br>
 
             <label for="crew_participants">Crew craft participants:</label>
-            <input type="number" min="0" name="crew_participants" id="crew_participants" value="{{ default_crew }}" required><br>
+            <input type="number" min="0" name="crew_participants" id="crew_participants" value="{{ form_data.crew_participants }}" required><br>
 
             <label for="coaches">Qualified coaches/leaders:</label>
-            <input type="number" min="0" name="coaches" id="coaches" value="{{ default_coaches }}" required><br>
+            <input type="number" min="0" name="coaches" id="coaches" value="{{ form_data.coaches }}" required><br>
 
             <button type="submit">Check</button>
         </form>
@@ -134,7 +134,7 @@
                     setTimeout(() => {
                         loading.style.display = 'none';
                         document.querySelector('.input-form').submit();
-                    }, 500);
+                    }, 1000);
                 });
             {% endif %}
         });


### PR DESCRIPTION
## Summary
- keep submitted form values on reload so users don't lose data
- delay automatic submission by one second after Dublin Airport data loads
- constrain the results area so long text wraps properly

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68528f5896a88323a820ef66c634ee4a