### PR TITLE
Support coach levels

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -45,8 +45,11 @@
             <label for="crew_participants">Crew craft participants:</label>
             <input type="number" min="0" name="crew_participants" id="crew_participants" value="{{ form_data.crew_participants }}" required><br>
 
-            <label for="coaches">BCAB Paddlesport/CANI Level 1</label>
-            <input type="number" min="0" name="coaches" id="coaches" value="{{ form_data.coaches }}" required><br>
+            <label for="level1_coaches">BCAB Paddlesport/CANI Level 1</label>
+            <input type="number" min="0" name="level1_coaches" id="level1_coaches" value="{{ form_data.level1_coaches }}" required><br>
+
+            <label for="level3_coaches">BCAB Coach/CANI Level 3</label>
+            <input type="number" min="0" name="level3_coaches" id="level3_coaches" value="{{ form_data.level3_coaches }}" required><br>
 
             <button type="submit" class="action-btn">Check again with above values</button>
 			<br>


### PR DESCRIPTION
## Summary
- parse coach qualification levels from `Conditions_and_Ratios.csv`
- check level 3 coaches for Moderate/Advanced water
- add level 1 and level 3 coach counters in form

## Testing
- `python -m py_compile app.py`
- *(fails: `python app.py` requires `requests`)*

------
https://chatgpt.com/codex/tasks/task_e_68529ec6cf4c832387c6b44f1b702cb5