### PR TITLE
Improve environment layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -89,10 +89,29 @@ h1 {
     background-color: #0056b3;
 }
 
+.env-container {
+    position: relative;
+    display: inline-block;
+}
+
 .env-definition {
     font-size: 8pt;
     font-style: italic;
-    margin: 5px 0;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    margin-top: 4px;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    padding: 5px;
+    width: 200px;
+    display: none;
+    z-index: 1000;
+    text-align: left;
+}
+
+.env-container:hover .env-definition {
+    display: block;
 }
 
 .subheading {

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,8 @@
             Loading latest weather data from Dublin Airport...
         </div>
         <form method="post" class="input-form">
+            <h3 class="subheading">Environment</h3>
+
             <label for="location">Location:</label>
             <select name="location" id="location">
                 {% for loc in locations %}
@@ -22,13 +24,15 @@
                 {% endfor %}
             </select><br>
 
-            <label for="environment">Environment:</label>
+            <div class="env-container">
+                <label for="environment" id="environment-label">Environment:</label>
+                <div id="env-definition" class="env-definition">{{ env_definitions[form_data.environment] }}</div>
+            </div>
             <select name="environment" id="environment">
                 {% for env in environments %}
                 <option value="{{ env }}" {% if env == form_data.environment %}selected{% endif %}>{{ env }}</option>
                 {% endfor %}
             </select><br>
-            <p id="env-definition" class="env-definition">{{ env_definitions[form_data.environment] }}</p>
 
             <label for="distance">Distance from shore (m):</label>
             <input type="number" step="1" min="0" name="distance" id="distance" value="{{ form_data.distance }}" required><br>


### PR DESCRIPTION
## Summary
- compact environment definition using tooltip overlay
- add Environment subheading before location input

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails without requests; installed requests and confirmed server starts)*

------
https://chatgpt.com/codex/tasks/task_e_6852b3fe8c6883239bbeaa0a847bd2ea