### PR TITLE
Fix overlay covering UI

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -11,7 +11,8 @@ body {
     inset: 0;
     background: rgba(0,0,0,0.3);
     backdrop-filter: blur(4px);
-    z-index: 0;
+    z-index: -1;
+    pointer-events: none;
 }
 
 #wind-arrow {


### PR DESCRIPTION
## Summary
- ensure blur overlay doesn't cover UI by lowering its z-index and disabling pointer events

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests`
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_6852da9b6a7c83238e27ccb505ba2788