### PR TITLE
Fix forecast slider not populated after auto submit

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -206,7 +206,6 @@
         }
 
         window.addEventListener('DOMContentLoaded', () => {
-            {% if not decision %}
             const loading = document.getElementById('loading-message');
             loading.classList.remove('hidden');
             fetch('/forecast')
@@ -227,10 +226,11 @@
                 .finally(() => {
                     setTimeout(() => {
                         loading.classList.add('hidden');
+                        {% if not decision %}
                         document.querySelector('.input-form').submit();
+                        {% endif %}
                     }, 1000);
                 });
-            {% endif %}
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- ensure forecast slider loads after decision

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685dd3a453f48323b4abbc12ff9c4b4d