### PR TITLE
Include weekday on forecast slider

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -222,7 +222,9 @@
             if (!item) return;
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
-            forecastTime.textContent = new Date(item.dtg).toLocaleString();
+            const dt = new Date(item.dtg);
+            const weekday = dt.toLocaleDateString('en-US', {weekday: 'long'});
+            forecastTime.textContent = `${weekday} ${dt.toLocaleString()}`;
             updateWindArrow();
             updateCurrentConditions();
             updateTideTable();


### PR DESCRIPTION
## Summary
- show day of week for selected forecast time

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685de35390c883239e9cb11e20ea4814