### PR TITLE
Improve forecast and tide table display

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -76,7 +76,11 @@ body {
 }
 
 .highlight-tide {
-    background-color: #fde68a;
+    background-color: #bfdbfe;
+}
+
+.tide-table {
+    font-size: 2em;
 }
 
 input[type="range"]::-webkit-slider-thumb {

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,9 +28,9 @@
                 <div>
                     <label for="forecast-slider" class="block font-medium">Forecast time</label>
                     <input type="range" id="forecast-slider" min="0" max="0" value="0" class="w-full">
-                    <div id="forecast-time" class="text-center text-sm mt-1"></div>
-                    <div id="tide-section" class="mt-2 text-sm">
-                        <table id="tide-table" class="tide-table w-full text-left border-collapse">
+                    <div id="forecast-time" class="text-center text-2xl sm:text-3xl font-bold w-full mt-1"></div>
+                    <div id="tide-section" class="mt-2">
+                        <table id="tide-table" class="tide-table w-full text-left border-collapse text-2xl">
                             <thead>
                                 <tr><th class="px-1">Time</th><th class="px-1">Tide</th></tr>
                             </thead>
@@ -59,6 +59,7 @@
             <a href="/swim"><img src="https://quacksolution.com/swim.png" alt="Swim" class="w-full h-auto"></a>
             <a href="/sail"><img src="https://quacksolution.com/sail.png" alt="Sail" class="w-full h-auto"></a>
         </div>
+        <a href="/" class="text-blue-700 underline block mt-4">Return to Home</a>
     </div>
 
     <script>

--- a/templates/paddle.html
+++ b/templates/paddle.html
@@ -118,6 +118,7 @@
 
             </form>
             <a href="https://britishcanoeingawarding.org.uk/wp-content/files/01042018BCABEnvironmentalDefinitionsDeploymentGuidanceForInstructorsCoachesLeadersV2-4Jan23.pdf" class="text-blue-700 underline block mt-4">See full BCAB Guidelines here</a>
+            <a href="/" class="text-blue-700 underline block mt-2">Return to Home</a>
         </div>
     </div>
 

--- a/templates/row.html
+++ b/templates/row.html
@@ -118,6 +118,7 @@
 
             </form>
             <a href="https://britishcanoeingawarding.org.uk/wp-content/files/01042018BCABEnvironmentalDefinitionsDeploymentGuidanceForInstructorsCoachesLeadersV2-4Jan23.pdf" class="text-blue-700 underline block mt-4">See full BCAB Guidelines here</a>
+            <a href="/" class="text-blue-700 underline block mt-2">Return to Home</a>
         </div>
     </div>
 

--- a/templates/sail.html
+++ b/templates/sail.html
@@ -118,6 +118,7 @@
 
             </form>
             <a href="https://britishcanoeingawarding.org.uk/wp-content/files/01042018BCABEnvironmentalDefinitionsDeploymentGuidanceForInstructorsCoachesLeadersV2-4Jan23.pdf" class="text-blue-700 underline block mt-4">See full BCAB Guidelines here</a>
+            <a href="/" class="text-blue-700 underline block mt-2">Return to Home</a>
         </div>
     </div>
 

--- a/templates/swim.html
+++ b/templates/swim.html
@@ -118,6 +118,7 @@
 
             </form>
             <a href="https://britishcanoeingawarding.org.uk/wp-content/files/01042018BCABEnvironmentalDefinitionsDeploymentGuidanceForInstructorsCoachesLeadersV2-4Jan23.pdf" class="text-blue-700 underline block mt-4">See full BCAB Guidelines here</a>
+            <a href="/" class="text-blue-700 underline block mt-2">Return to Home</a>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- enlarge forecast and tide display on home page
- style tide table for larger text
- switch tide highlight colour to light blue
- add return-home links to all pages

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685ef414860c8323beb582d92587936e