### PR TITLE
Improve video overlay tint and font hierarchy

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,5 +1,6 @@
 html {
-    font-size: 200%;
+    /* Use a modest base font size for better hierarchy */
+    font-size: 125%;
 }
 
 body {
@@ -25,7 +26,9 @@ body {
 #bg-overlay {
     position: fixed;
     inset: 0;
-    background: rgba(0,0,0,0.3);
+    /* Tint overlay the same shade as the video background so
+       the letterbox colour isn't lost once styles load */
+    background: rgba(46, 83, 125, 0.45);
     backdrop-filter: blur(0px);
     z-index: -1;
     pointer-events: none;
@@ -82,7 +85,7 @@ body {
 }
 
 .tide-table {
-    font-size: 2em;
+    font-size: 1.25em;
 }
 
 input[type="range"]::-webkit-slider-thumb {


### PR DESCRIPTION
## Summary
- use same blue tint on the background overlay so the video bars stay blue
- set a more reasonable base font size for better hierarchy
- shrink tide table font size slightly

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685efe3ae0f8832395a971f3b8e2f56d