### PR TITLE
Add marine data fetch to swim page

### DIFF
--- a/templates/swim.html
+++ b/templates/swim.html
@@ -230,9 +230,10 @@
             if (loading) loading.classList.remove('hidden');
             Promise.all([
                 fetch('/forecast').then(r => r.json()),
-                fetch('/tides').then(r => r.json())
+                fetch('/tides').then(r => r.json()),
+                fetch('https://marine-api.open-meteo.com/v1/marine?latitude=53.583679&longitude=-6.100253&hourly=wave_height,sea_surface_temperature&current=wave_height,sea_surface_temperature&wind_speed_unit=ms').then(r => r.json())
             ])
-                .then(([fData, tData]) => {
+                .then(([fData, tData, marine]) => {
                     if (!fData.error && fData.length) {
                         forecastData = fData;
                         forecastSlider.max = fData.length - 1;
@@ -244,6 +245,12 @@
                     if (tData && !tData.error) {
                         tideData = tData;
                         updateTideTable();
+                    }
+                    if (marine && !marine.error && marine.current) {
+                        const waveEl = document.getElementById('wave_conditions');
+                        const tempEl = document.getElementById('sea_temperature');
+                        waveEl.textContent = `${marine.current.wave_height} m`;
+                        tempEl.textContent = `${marine.current.sea_surface_temperature} °C`;
                     }
                 })
                 .catch(() => {


### PR DESCRIPTION
## Summary
- fetch wave height and sea surface temperature from open-meteo
- display results in swim page alongside other weather data

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68600743dba08323886af5b554282161