### PR TITLE
Add colour scales & new home link

### DIFF
--- a/templates/paddle.html
+++ b/templates/paddle.html
@@ -118,7 +118,11 @@
 
             </form>
             <a href="https://britishcanoeingawarding.org.uk/wp-content/files/01042018BCABEnvironmentalDefinitionsDeploymentGuidanceForInstructorsCoachesLeadersV2-4Jan23.pdf" class="text-blue-700 underline block mt-4">See full BCAB Guidelines here</a>
-            <a href="/" class="text-blue-700 underline block mt-2">Return to Home</a>
+        </div>
+        <div class="mt-4 text-center">
+            <a href="/">
+                <img src="http://quacksolution.com/home.png" alt="Home" width="50" height="50" class="mx-auto">
+            </a>
         </div>
     </div>
 

--- a/templates/row.html
+++ b/templates/row.html
@@ -118,7 +118,11 @@
 
             </form>
             <a href="https://britishcanoeingawarding.org.uk/wp-content/files/01042018BCABEnvironmentalDefinitionsDeploymentGuidanceForInstructorsCoachesLeadersV2-4Jan23.pdf" class="text-blue-700 underline block mt-4">See full BCAB Guidelines here</a>
-            <a href="/" class="text-blue-700 underline block mt-2">Return to Home</a>
+        </div>
+        <div class="mt-4 text-center">
+            <a href="/">
+                <img src="http://quacksolution.com/home.png" alt="Home" width="50" height="50" class="mx-auto">
+            </a>
         </div>
     </div>
 

--- a/templates/sail.html
+++ b/templates/sail.html
@@ -118,7 +118,11 @@
 
             </form>
             
-            <a href="/" class="text-blue-700 underline block mt-2">Return to Home</a>
+        </div>
+        <div class="mt-4 text-center">
+            <a href="/">
+                <img src="http://quacksolution.com/home.png" alt="Home" width="50" height="50" class="mx-auto">
+            </a>
         </div>
     </div>
 

--- a/templates/swim.html
+++ b/templates/swim.html
@@ -88,7 +88,11 @@
 
 
             </form>
-            <a href="/" class="block mt-2"><img src="http://quacksolution.com/home.png" alt="Home" class="inline-block"></a>
+        </div>
+        <div class="mt-4 text-center">
+            <a href="/">
+                <img src="http://quacksolution.com/home.png" alt="Home" width="50" height="50" class="mx-auto">
+            </a>
         </div>
     </div>
 
@@ -187,6 +191,7 @@
                 tempEl.textContent = '-';
                 waveEl.textContent = '-';
             }
+            applyColorScales();
         }
 
         function updateSunTimes(dateStr) {
@@ -201,6 +206,36 @@
                 sunriseEl.textContent = '-';
                 sunsetEl.textContent = '-';
             }
+        }
+
+        function scaleColor(val, min, max, start, end) {
+            const ratio = Math.min(Math.max((val - min) / (max - min), 0), 1);
+            const r = Math.round(start[0] + (end[0] - start[0]) * ratio);
+            const g = Math.round(start[1] + (end[1] - start[1]) * ratio);
+            const b = Math.round(start[2] + (end[2] - start[2]) * ratio);
+            return `rgb(${r},${g},${b})`;
+        }
+
+        function applyColorScales() {
+            const windVal = parseFloat(windSpeedInput.textContent) || 0;
+            document.getElementById('wind_speed').style.color = scaleColor(windVal, 0, 50, [0,128,0], [255,0,0]);
+
+            const waveVal = parseFloat(document.getElementById('wave_conditions').textContent) || 0;
+            document.getElementById('wave_conditions').style.color = scaleColor(waveVal, 0, 2, [0,128,0], [255,0,0]);
+
+            const seaVal = parseFloat(document.getElementById('sea_temperature').textContent) || 0;
+            document.getElementById('sea_temperature').style.color = scaleColor(seaVal, 7, 20, [0,0,255], [255,0,0]);
+
+            const airEl = document.getElementById('air_temperature');
+            if (airEl) {
+                const airVal = parseFloat(airEl.textContent) || 0;
+                airEl.style.color = scaleColor(airVal, 0, 30, [0,0,255], [255,0,0]);
+            }
+
+            const qualityEl = document.getElementById('water_quality');
+            const qual = qualityEl.textContent.trim();
+            const qColors = {"Excellent": "blue", "Good": "green", "Sufficient": "orange", "Poor": "red"};
+            if (qColors[qual]) qualityEl.style.color = qColors[qual];
         }
 
         function updateCurrentConditions() {
@@ -232,6 +267,7 @@
             updateWindArrow();
             updateCurrentConditions();
             updateTideTable();
+            applyColorScales();
         }
 
 
@@ -256,6 +292,7 @@
         // Initialize on load
         updateWindArrow();
         updateCurrentConditions();
+        applyColorScales();
 
         window.addEventListener('DOMContentLoaded', () => {
             const loading = document.getElementById('loading-message');
@@ -299,6 +336,7 @@
                     }
                     if (quality && !quality.error && quality.status) {
                         waterQualityEl.textContent = quality.status;
+                        applyColorScales();
                     }
                     applyForecast();
                 })


### PR DESCRIPTION
## Summary
- add gradient based colour scales for swim data
- move home link outside the form wrapper and display it as a centred 50x50 image

## Testing
- `python -m py_compile app.py`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_68601cde70ec8323af24bcabe813f6ee