### PR TITLE
Replace forecast slider with date picker

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -26,8 +26,8 @@
 
             <form method="post" class="input-form grid gap-4">
                 <div>
-                    <label for="forecast-slider" class="block font-medium">Forecast time</label>
-                    <input type="range" id="forecast-slider" min="0" max="0" value="0" class="w-full">
+                    <label for="forecast-picker" class="block font-medium">Forecast time</label>
+                    <input type="datetime-local" id="forecast-picker" class="w-full">
                     <div id="forecast-time" class="text-center text-1xl sm:text-2xl font-bold w-full mt-1"></div>
                     <div id="tide-section" class="mt-2">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse text-lg">
@@ -58,7 +58,7 @@
         const windDirInput = document.getElementById('wind_direction') || {value: 0};
         const windArrow = document.getElementById('wind-arrow');
         const windSpeedInput = document.getElementById('wind_speed') || {value: 0};
-        const forecastSlider = document.getElementById('forecast-slider');
+        const forecastPicker = document.getElementById('forecast-picker');
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
@@ -116,8 +116,9 @@
         function updateTideTable() {
             if (!tideData.length) return;
             let selDate = null;
-            if (forecastData.length) {
-                const sel = forecastData[parseInt(forecastSlider.value)];
+            if (forecastData.length && forecastPicker.value) {
+                const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+                const sel = forecastData[idx];
                 if (sel) selDate = new Date(sel.dtg);
             }
             if (!selDate) {
@@ -152,9 +153,10 @@
         }
 
         function applyForecast() {
-            const idx = parseInt(forecastSlider.value);
+            const idx = getNearestForecastIndex(new Date(forecastPicker.value));
             const item = forecastData[idx];
             if (!item) return;
+            forecastPicker.value = new Date(item.dtg).toISOString().slice(0,16);
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
             const dt = new Date(item.dtg);
@@ -181,8 +183,8 @@
         if (envSelect) envSelect.addEventListener('change', updateEnvDefinition);
         if (windDirInput.addEventListener) windDirInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
         if (windSpeedInput.addEventListener) windSpeedInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
-        if (forecastSlider) {
-            forecastSlider.addEventListener('input', () => {
+        if (forecastPicker) {
+            forecastPicker.addEventListener('change', () => {
                 applyForecast();
             });
         }
@@ -196,7 +198,7 @@
             reloadBtn.addEventListener('click', () => {
                 if (forecastData.length) {
                     const idx = getNearestForecastIndex(new Date());
-                    forecastSlider.value = idx;
+                    forecastPicker.value = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
                     applyForecast();
                 }
             });
@@ -212,8 +214,10 @@
                 .then(([fData, tData]) => {
                     if (!fData.error && fData.length) {
                         forecastData = fData;
-                        forecastSlider.max = fData.length - 1;
-                        forecastSlider.value = getNearestForecastIndex(new Date());
+                        forecastPicker.min = new Date(fData[0].dtg).toISOString().slice(0,16);
+                        forecastPicker.max = new Date(fData[fData.length - 1].dtg).toISOString().slice(0,16);
+                        const idx = getNearestForecastIndex(new Date());
+                        forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
                         applyForecast();
                     } else if (loading) {
                         loading.textContent = 'Could not load weather data.';

--- a/templates/paddle.html
+++ b/templates/paddle.html
@@ -34,8 +34,9 @@
 
             <form method="post" class="input-form grid gap-4">
                 <div>
-                   <div id="forecast-time" class="text-center text-1xl sm:text-2xl w-full mt-1"></div>
-					<input type="range" id="forecast-slider" min="0" max="0" value="0" class="w-full">
+                    <label for="forecast-picker" class="block font-medium">Forecast time</label>
+                    <input type="datetime-local" id="forecast-picker" class="w-full">
+                    <div id="forecast-time" class="text-center text-1xl sm:text-2xl w-full mt-1"></div>
                     <div id="tide-section" class="mt-2">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse text-lg">
                             <thead>
@@ -130,7 +131,7 @@
         const windDirInput = document.getElementById('wind_direction');
         const windArrow = document.getElementById('wind-arrow');
         const windSpeedInput = document.getElementById('wind_speed');
-        const forecastSlider = document.getElementById('forecast-slider');
+        const forecastPicker = document.getElementById('forecast-picker');
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
@@ -186,8 +187,9 @@
         function updateTideTable() {
             if (!tideData.length) return;
             let selDate = null;
-            if (forecastData.length) {
-                const sel = forecastData[parseInt(forecastSlider.value)];
+            if (forecastData.length && forecastPicker.value) {
+                const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+                const sel = forecastData[idx];
                 if (sel) selDate = new Date(sel.dtg);
             }
             if (!selDate) {
@@ -222,9 +224,10 @@
         }
 
         function applyForecast() {
-            const idx = parseInt(forecastSlider.value);
+            const idx = getNearestForecastIndex(new Date(forecastPicker.value));
             const item = forecastData[idx];
             if (!item) return;
+            forecastPicker.value = new Date(item.dtg).toISOString().slice(0,16);
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
             const dt = new Date(item.dtg);
@@ -251,8 +254,8 @@
         envSelect.addEventListener('change', updateEnvDefinition);
         windDirInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
         windSpeedInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
-        if (forecastSlider) {
-            forecastSlider.addEventListener('input', () => {
+        if (forecastPicker) {
+            forecastPicker.addEventListener('change', () => {
                 applyForecast();
             });
         }
@@ -266,7 +269,7 @@
             reloadBtn.addEventListener('click', () => {
                 if (forecastData.length) {
                     const idx = getNearestForecastIndex(new Date());
-                    forecastSlider.value = idx;
+                    forecastPicker.value = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
                     applyForecast();
                 }
             });
@@ -282,8 +285,10 @@
                 .then(([fData, tData]) => {
                     if (!fData.error && fData.length) {
                         forecastData = fData;
-                        forecastSlider.max = fData.length - 1;
-                        forecastSlider.value = getNearestForecastIndex(new Date());
+                        forecastPicker.min = new Date(fData[0].dtg).toISOString().slice(0,16);
+                        forecastPicker.max = new Date(fData[fData.length - 1].dtg).toISOString().slice(0,16);
+                        const idx = getNearestForecastIndex(new Date());
+                        forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
                         applyForecast();
                     } else if (loading) {
                         loading.textContent = 'Could not load weather data.';

--- a/templates/row.html
+++ b/templates/row.html
@@ -34,8 +34,8 @@
 
             <form method="post" class="input-form grid gap-4">
                 <div>
-                    <label for="forecast-slider" class="block font-medium">Forecast time</label>
-                    <input type="range" id="forecast-slider" min="0" max="0" value="0" class="w-full">
+                    <label for="forecast-picker" class="block font-medium">Forecast time</label>
+                    <input type="datetime-local" id="forecast-picker" class="w-full">
                     <div id="forecast-time" class="text-center text-sm mt-1"></div>
                     <div id="tide-section" class="mt-2 text-sm">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse">
@@ -130,7 +130,7 @@
         const windDirInput = document.getElementById('wind_direction');
         const windArrow = document.getElementById('wind-arrow');
         const windSpeedInput = document.getElementById('wind_speed');
-        const forecastSlider = document.getElementById('forecast-slider');
+        const forecastPicker = document.getElementById('forecast-picker');
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
@@ -186,8 +186,9 @@
         function updateTideTable() {
             if (!tideData.length) return;
             let selDate = null;
-            if (forecastData.length) {
-                const sel = forecastData[parseInt(forecastSlider.value)];
+            if (forecastData.length && forecastPicker.value) {
+                const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+                const sel = forecastData[idx];
                 if (sel) selDate = new Date(sel.dtg);
             }
             if (!selDate) {
@@ -222,9 +223,10 @@
         }
 
         function applyForecast() {
-            const idx = parseInt(forecastSlider.value);
+            const idx = getNearestForecastIndex(new Date(forecastPicker.value));
             const item = forecastData[idx];
             if (!item) return;
+            forecastPicker.value = new Date(item.dtg).toISOString().slice(0,16);
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
             const dt = new Date(item.dtg);
@@ -251,8 +253,8 @@
         envSelect.addEventListener('change', updateEnvDefinition);
         windDirInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
         windSpeedInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
-        if (forecastSlider) {
-            forecastSlider.addEventListener('input', () => {
+        if (forecastPicker) {
+            forecastPicker.addEventListener('change', () => {
                 applyForecast();
             });
         }
@@ -266,7 +268,7 @@
             reloadBtn.addEventListener('click', () => {
                 if (forecastData.length) {
                     const idx = getNearestForecastIndex(new Date());
-                    forecastSlider.value = idx;
+                    forecastPicker.value = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
                     applyForecast();
                 }
             });
@@ -282,8 +284,10 @@
                 .then(([fData, tData]) => {
                     if (!fData.error && fData.length) {
                         forecastData = fData;
-                        forecastSlider.max = fData.length - 1;
-                        forecastSlider.value = getNearestForecastIndex(new Date());
+                        forecastPicker.min = new Date(fData[0].dtg).toISOString().slice(0,16);
+                        forecastPicker.max = new Date(fData[fData.length - 1].dtg).toISOString().slice(0,16);
+                        const idx = getNearestForecastIndex(new Date());
+                        forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
                         applyForecast();
                     } else if (loading) {
                         loading.textContent = 'Could not load weather data.';

--- a/templates/sail.html
+++ b/templates/sail.html
@@ -33,8 +33,9 @@
             {% endif %}
 
             <form method="post" class="input-form grid gap-4">
-               <div id="forecast-time" class="text-center text-1xl sm:text-2xl w-full mt-1"></div>
-					<input type="range" id="forecast-slider" min="0" max="0" value="0" class="w-full">
+                <label for="forecast-picker" class="block font-medium">Forecast time</label>
+                <input type="datetime-local" id="forecast-picker" class="w-full">
+                <div id="forecast-time" class="text-center text-1xl sm:text-2xl w-full mt-1"></div>
                     <div id="tide-section" class="mt-2">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse text-lg">
                             <thead>
@@ -128,7 +129,7 @@
         const windDirInput = document.getElementById('wind_direction');
         const windArrow = document.getElementById('wind-arrow');
         const windSpeedInput = document.getElementById('wind_speed');
-        const forecastSlider = document.getElementById('forecast-slider');
+        const forecastPicker = document.getElementById('forecast-picker');
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
@@ -184,8 +185,9 @@
         function updateTideTable() {
             if (!tideData.length) return;
             let selDate = null;
-            if (forecastData.length) {
-                const sel = forecastData[parseInt(forecastSlider.value)];
+            if (forecastData.length && forecastPicker.value) {
+                const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+                const sel = forecastData[idx];
                 if (sel) selDate = new Date(sel.dtg);
             }
             if (!selDate) {
@@ -220,9 +222,10 @@
         }
 
         function applyForecast() {
-            const idx = parseInt(forecastSlider.value);
+            const idx = getNearestForecastIndex(new Date(forecastPicker.value));
             const item = forecastData[idx];
             if (!item) return;
+            forecastPicker.value = new Date(item.dtg).toISOString().slice(0,16);
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
             const dt = new Date(item.dtg);
@@ -249,8 +252,8 @@
         envSelect.addEventListener('change', updateEnvDefinition);
         windDirInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
         windSpeedInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
-        if (forecastSlider) {
-            forecastSlider.addEventListener('input', () => {
+        if (forecastPicker) {
+            forecastPicker.addEventListener('change', () => {
                 applyForecast();
             });
         }
@@ -264,7 +267,7 @@
             reloadBtn.addEventListener('click', () => {
                 if (forecastData.length) {
                     const idx = getNearestForecastIndex(new Date());
-                    forecastSlider.value = idx;
+                    forecastPicker.value = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
                     applyForecast();
                 }
             });
@@ -280,8 +283,10 @@
                 .then(([fData, tData]) => {
                     if (!fData.error && fData.length) {
                         forecastData = fData;
-                        forecastSlider.max = fData.length - 1;
-                        forecastSlider.value = getNearestForecastIndex(new Date());
+                        forecastPicker.min = new Date(fData[0].dtg).toISOString().slice(0,16);
+                        forecastPicker.max = new Date(fData[fData.length - 1].dtg).toISOString().slice(0,16);
+                        const idx = getNearestForecastIndex(new Date());
+                        forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
                         applyForecast();
                     } else if (loading) {
                         loading.textContent = 'Could not load weather data.';

--- a/templates/swim.html
+++ b/templates/swim.html
@@ -26,10 +26,9 @@
 
             <form method="post" class="input-form grid gap-4">
                 <div>
-                    
-                    
+                    <label for="forecast-picker" class="block font-medium">Forecast time</label>
+                    <input type="datetime-local" id="forecast-picker" class="w-full">
                     <div id="forecast-time" class="text-center text-1xl sm:text-2xl w-full mt-1"></div>
-					<input type="range" id="forecast-slider" min="0" max="0" value="0" class="w-full">
                     <div id="tide-section" class="mt-2">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse text-lg">
                             <thead>
@@ -100,7 +99,7 @@
         const windDirInput = document.getElementById('wind_direction');
         const windArrow = document.getElementById('wind-arrow');
         const windSpeedInput = document.getElementById('wind_speed');
-        const forecastSlider = document.getElementById('forecast-slider');
+        const forecastPicker = document.getElementById('forecast-picker');
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
@@ -153,8 +152,9 @@
         function updateTideTable() {
             if (!tideData.length) return;
             let selDate = null;
-            if (forecastData.length) {
-                const sel = forecastData[parseInt(forecastSlider.value)];
+            if (forecastData.length && forecastPicker.value) {
+                const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+                const sel = forecastData[idx];
                 if (sel) selDate = new Date(sel.dtg);
             }
             if (!selDate) {
@@ -246,9 +246,10 @@
         }
 
         function applyForecast() {
-            const idx = parseInt(forecastSlider.value);
+            const idx = getNearestForecastIndex(new Date(forecastPicker.value));
             const item = forecastData[idx];
             if (!item) return;
+            forecastPicker.value = new Date(item.dtg).toISOString().slice(0,16);
             windSpeedInput.textContent = item.speed;
             windDirInput.textContent = item.direction;
             const airEl = document.getElementById('air_temperature');
@@ -283,8 +284,8 @@
             windArrow.style.transform = `rotate(${angle - 180}deg)`;
         }
 
-        if (forecastSlider) {
-            forecastSlider.addEventListener('input', () => {
+        if (forecastPicker) {
+            forecastPicker.addEventListener('change', () => {
                 applyForecast();
             });
         }
@@ -307,8 +308,10 @@
                 .then(([fData, tData, marine, sun, quality]) => {
                     if (!fData.error && fData.length) {
                         forecastData = fData;
-                        forecastSlider.max = fData.length - 1;
-                        forecastSlider.value = getNearestForecastIndex(new Date());
+                        forecastPicker.min = new Date(fData[0].dtg).toISOString().slice(0,16);
+                        forecastPicker.max = new Date(fData[fData.length - 1].dtg).toISOString().slice(0,16);
+                        const idx = getNearestForecastIndex(new Date());
+                        forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
                         applyForecast();
                     } else if (loading) {
                         loading.textContent = 'Could not load weather data.';


### PR DESCRIPTION
## Summary
- switch forecast slider UI to a `datetime-local` picker on all pages
- update JavaScript logic to use the new control

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from jinja2 import Environment, FileSystemLoader, TemplateSyntaxError
env=Environment(loader=FileSystemLoader('templates'))
for t in env.list_templates():
    env.get_template(t)
print('Templates OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68602e08b1108323b4940005b8288dcd