### PR TITLE
Add scroll wheel forecast picker

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -93,3 +93,15 @@ input[type="range"]::-moz-range-thumb {
     width: 35px;
     height: 35px;
 }
+.scroll-wheel {
+    font-family: 'Courier New', monospace;
+    background-color: #f7f7f7;
+    border: 2px solid #888;
+    border-radius: 8px;
+    padding: 4px;
+    height: 6rem;
+    overflow-y: auto;
+}
+.scroll-wheel option {
+    padding: 2px 4px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,7 @@
             <form method="post" class="input-form grid gap-4">
                 <div>
                     <label for="forecast-picker" class="block font-medium">Forecast time</label>
-                    <input type="datetime-local" id="forecast-picker" class="w-full">
+                    <select id="forecast-picker" size="5" class="scroll-wheel w-full"></select>
                     <div id="forecast-time" class="text-center text-1xl sm:text-2xl font-bold w-full mt-1"></div>
                     <div id="tide-section" class="mt-2">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse text-lg">
@@ -62,6 +62,16 @@
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
+        function populateForecastOptions(data) {
+            forecastPicker.innerHTML = "";
+            data.forEach(item => {
+                const dt = new Date(item.dtg);
+                const opt = document.createElement("option");
+                opt.value = dt.toISOString().slice(0,16);
+                opt.textContent = dt.toLocaleDateString("en-GB", {weekday:"short", day:"numeric", month:"short"}) + " " + dt.toLocaleTimeString([], {hour:"2-digit", minute:"2-digit"});
+                forecastPicker.appendChild(opt);
+            });
+        }
         const arrowImages = {
             1: "http://quacksolution.com/force1.png",
             2: "http://quacksolution.com/force2.png",
@@ -214,8 +224,8 @@
                 .then(([fData, tData]) => {
                     if (!fData.error && fData.length) {
                         forecastData = fData;
-                        forecastPicker.min = new Date(fData[0].dtg).toISOString().slice(0,16);
-                        forecastPicker.max = new Date(fData[fData.length - 1].dtg).toISOString().slice(0,16);
+                        populateForecastOptions(forecastData);
+
                         const idx = getNearestForecastIndex(new Date());
                         forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
                         applyForecast();

--- a/templates/paddle.html
+++ b/templates/paddle.html
@@ -35,7 +35,7 @@
             <form method="post" class="input-form grid gap-4">
                 <div>
                     <label for="forecast-picker" class="block font-medium">Forecast time</label>
-                    <input type="datetime-local" id="forecast-picker" class="w-full">
+                    <select id="forecast-picker" size="5" class="scroll-wheel w-full"></select>
                     <div id="forecast-time" class="text-center text-1xl sm:text-2xl w-full mt-1"></div>
                     <div id="tide-section" class="mt-2">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse text-lg">
@@ -135,6 +135,16 @@
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
+        function populateForecastOptions(data) {
+            forecastPicker.innerHTML = "";
+            data.forEach(item => {
+                const dt = new Date(item.dtg);
+                const opt = document.createElement("option");
+                opt.value = dt.toISOString().slice(0,16);
+                opt.textContent = dt.toLocaleDateString("en-GB", {weekday:"short", day:"numeric", month:"short"}) + " " + dt.toLocaleTimeString([], {hour:"2-digit", minute:"2-digit"});
+                forecastPicker.appendChild(opt);
+            });
+        }
         const arrowImages = {
             1: "http://quacksolution.com/force1.png",
             2: "http://quacksolution.com/force2.png",
@@ -285,8 +295,8 @@
                 .then(([fData, tData]) => {
                     if (!fData.error && fData.length) {
                         forecastData = fData;
-                        forecastPicker.min = new Date(fData[0].dtg).toISOString().slice(0,16);
-                        forecastPicker.max = new Date(fData[fData.length - 1].dtg).toISOString().slice(0,16);
+                        populateForecastOptions(forecastData);
+
                         const idx = getNearestForecastIndex(new Date());
                         forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
                         applyForecast();

--- a/templates/row.html
+++ b/templates/row.html
@@ -35,7 +35,7 @@
             <form method="post" class="input-form grid gap-4">
                 <div>
                     <label for="forecast-picker" class="block font-medium">Forecast time</label>
-                    <input type="datetime-local" id="forecast-picker" class="w-full">
+                    <select id="forecast-picker" size="5" class="scroll-wheel w-full"></select>
                     <div id="forecast-time" class="text-center text-sm mt-1"></div>
                     <div id="tide-section" class="mt-2 text-sm">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse">
@@ -134,6 +134,16 @@
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
+        function populateForecastOptions(data) {
+            forecastPicker.innerHTML = "";
+            data.forEach(item => {
+                const dt = new Date(item.dtg);
+                const opt = document.createElement("option");
+                opt.value = dt.toISOString().slice(0,16);
+                opt.textContent = dt.toLocaleDateString("en-GB", {weekday:"short", day:"numeric", month:"short"}) + " " + dt.toLocaleTimeString([], {hour:"2-digit", minute:"2-digit"});
+                forecastPicker.appendChild(opt);
+            });
+        }
         const arrowImages = {
             1: "http://quacksolution.com/force1.png",
             2: "http://quacksolution.com/force2.png",
@@ -284,8 +294,8 @@
                 .then(([fData, tData]) => {
                     if (!fData.error && fData.length) {
                         forecastData = fData;
-                        forecastPicker.min = new Date(fData[0].dtg).toISOString().slice(0,16);
-                        forecastPicker.max = new Date(fData[fData.length - 1].dtg).toISOString().slice(0,16);
+                        populateForecastOptions(forecastData);
+
                         const idx = getNearestForecastIndex(new Date());
                         forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
                         applyForecast();

--- a/templates/sail.html
+++ b/templates/sail.html
@@ -34,7 +34,7 @@
 
             <form method="post" class="input-form grid gap-4">
                 <label for="forecast-picker" class="block font-medium">Forecast time</label>
-                <input type="datetime-local" id="forecast-picker" class="w-full">
+                <select id="forecast-picker" size="5" class="scroll-wheel w-full"></select>
                 <div id="forecast-time" class="text-center text-1xl sm:text-2xl w-full mt-1"></div>
                     <div id="tide-section" class="mt-2">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse text-lg">
@@ -133,6 +133,16 @@
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
+        function populateForecastOptions(data) {
+            forecastPicker.innerHTML = "";
+            data.forEach(item => {
+                const dt = new Date(item.dtg);
+                const opt = document.createElement("option");
+                opt.value = dt.toISOString().slice(0,16);
+                opt.textContent = dt.toLocaleDateString("en-GB", {weekday:"short", day:"numeric", month:"short"}) + " " + dt.toLocaleTimeString([], {hour:"2-digit", minute:"2-digit"});
+                forecastPicker.appendChild(opt);
+            });
+        }
         const arrowImages = {
             1: "http://quacksolution.com/force1.png",
             2: "http://quacksolution.com/force2.png",
@@ -283,8 +293,8 @@
                 .then(([fData, tData]) => {
                     if (!fData.error && fData.length) {
                         forecastData = fData;
-                        forecastPicker.min = new Date(fData[0].dtg).toISOString().slice(0,16);
-                        forecastPicker.max = new Date(fData[fData.length - 1].dtg).toISOString().slice(0,16);
+                        populateForecastOptions(forecastData);
+
                         const idx = getNearestForecastIndex(new Date());
                         forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
                         applyForecast();

--- a/templates/swim.html
+++ b/templates/swim.html
@@ -86,7 +86,7 @@
                 </div>
                 <br>   
                 <label class="block font-medium sm:text-sm">Change date:</label>
-                <input type="datetime-local" id="forecast-picker" class="w-full">
+                <select id="forecast-picker" size="5" class="scroll-wheel w-full"></select>
             </form>
         </div>
         <div class="mt-4 text-center">
@@ -104,6 +104,16 @@
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
+        function populateForecastOptions(data) {
+            forecastPicker.innerHTML = "";
+            data.forEach(item => {
+                const dt = new Date(item.dtg);
+                const opt = document.createElement("option");
+                opt.value = dt.toISOString().slice(0,16);
+                opt.textContent = dt.toLocaleDateString("en-GB", {weekday:"short", day:"numeric", month:"short"}) + " " + dt.toLocaleTimeString([], {hour:"2-digit", minute:"2-digit"});
+                forecastPicker.appendChild(opt);
+            });
+        }
         const waterQualityEl = document.getElementById('water_quality');
         let seaTemps = JSON.parse(localStorage.getItem('seaTemps') || 'null');
         let sunTimes = JSON.parse(localStorage.getItem('sunTimes') || 'null');
@@ -309,8 +319,7 @@
                 .then(([fData, tData, marine, sun, quality]) => {
                     if (!fData.error && fData.length) {
                         forecastData = fData;
-                        forecastPicker.min = new Date(fData[0].dtg).toISOString().slice(0,16);
-                        forecastPicker.max = new Date(fData[fData.length - 1].dtg).toISOString().slice(0,16);
+                          populateForecastOptions(forecastData);
                         const idx = getNearestForecastIndex(new Date());
                         forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
                         applyForecast();


### PR DESCRIPTION
## Summary
- switch datetime picker to scroll wheel select
- style scroll wheel with retro font
- populate forecast options via JavaScript

## Testing
- `python -m py_compile app.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603ae22260832397a2b7312bf2da34