### PR TITLE
Switch forecast picker to horizontal scroll cards

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -105,3 +105,23 @@ input[type="range"]::-moz-range-thumb {
 .scroll-wheel option {
     padding: 2px 4px;
 }
+
+.date-scroll {
+    display: flex;
+    overflow-x: auto;
+    gap: 0.5rem;
+    padding: 4px 0;
+}
+.forecast-card {
+    flex: 0 0 auto;
+    font-family: 'Courier New', monospace;
+    background-color: #f7f7f7;
+    border: 2px solid #888;
+    border-radius: 8px;
+    padding: 4px 8px;
+    cursor: pointer;
+    user-select: none;
+}
+.forecast-card.selected {
+    background-color: #bfdbfe;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,7 @@
             <form method="post" class="input-form grid gap-4">
                 <div>
                     <label for="forecast-picker" class="block font-medium">Forecast time</label>
-                    <select id="forecast-picker" size="5" class="scroll-wheel w-full"></select>
+                    <div id="forecast-picker" class="date-scroll w-full"></div>
                     <div id="forecast-time" class="text-center text-1xl sm:text-2xl font-bold w-full mt-1"></div>
                     <div id="tide-section" class="mt-2">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse text-lg">
@@ -62,14 +62,28 @@
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
+        let selectedForecast = '';
+
+        function updateSelectedCard() {
+            forecastPicker.querySelectorAll('.forecast-card').forEach(c => {
+                c.classList.toggle('selected', c.dataset.value === selectedForecast);
+            });
+        }
+
         function populateForecastOptions(data) {
-            forecastPicker.innerHTML = "";
+            forecastPicker.innerHTML = '';
             data.forEach(item => {
                 const dt = new Date(item.dtg);
-                const opt = document.createElement("option");
-                opt.value = dt.toISOString().slice(0,16);
-                opt.textContent = dt.toLocaleDateString("en-GB", {weekday:"short", day:"numeric", month:"short"}) + " " + dt.toLocaleTimeString([], {hour:"2-digit", minute:"2-digit"});
-                forecastPicker.appendChild(opt);
+                const card = document.createElement('div');
+                card.className = 'forecast-card';
+                card.dataset.value = dt.toISOString().slice(0,16);
+                card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
+                card.addEventListener('click', () => {
+                    selectedForecast = card.dataset.value;
+                    updateSelectedCard();
+                    applyForecast();
+                });
+                forecastPicker.appendChild(card);
             });
         }
         const arrowImages = {
@@ -126,8 +140,8 @@
         function updateTideTable() {
             if (!tideData.length) return;
             let selDate = null;
-            if (forecastData.length && forecastPicker.value) {
-                const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+            if (forecastData.length && selectedForecast) {
+                const idx = getNearestForecastIndex(new Date(selectedForecast));
                 const sel = forecastData[idx];
                 if (sel) selDate = new Date(sel.dtg);
             }
@@ -163,10 +177,11 @@
         }
 
         function applyForecast() {
-            const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+            const idx = getNearestForecastIndex(new Date(selectedForecast));
             const item = forecastData[idx];
             if (!item) return;
-            forecastPicker.value = new Date(item.dtg).toISOString().slice(0,16);
+            selectedForecast = new Date(item.dtg).toISOString().slice(0,16);
+            updateSelectedCard();
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
             const dt = new Date(item.dtg);
@@ -193,11 +208,7 @@
         if (envSelect) envSelect.addEventListener('change', updateEnvDefinition);
         if (windDirInput.addEventListener) windDirInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
         if (windSpeedInput.addEventListener) windSpeedInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
-        if (forecastPicker) {
-            forecastPicker.addEventListener('change', () => {
-                applyForecast();
-            });
-        }
+
 
         // Initialize on load
         updateWindArrow();
@@ -208,7 +219,8 @@
             reloadBtn.addEventListener('click', () => {
                 if (forecastData.length) {
                     const idx = getNearestForecastIndex(new Date());
-                    forecastPicker.value = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
+                    selectedForecast = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
+                    updateSelectedCard();
                     applyForecast();
                 }
             });
@@ -227,7 +239,8 @@
                         populateForecastOptions(forecastData);
 
                         const idx = getNearestForecastIndex(new Date());
-                        forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        selectedForecast = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        updateSelectedCard();
                         applyForecast();
                     } else if (loading) {
                         loading.textContent = 'Could not load weather data.';

--- a/templates/paddle.html
+++ b/templates/paddle.html
@@ -35,7 +35,7 @@
             <form method="post" class="input-form grid gap-4">
                 <div>
                     <label for="forecast-picker" class="block font-medium">Forecast time</label>
-                    <select id="forecast-picker" size="5" class="scroll-wheel w-full"></select>
+                    <div id="forecast-picker" class="date-scroll w-full"></div>
                     <div id="forecast-time" class="text-center text-1xl sm:text-2xl w-full mt-1"></div>
                     <div id="tide-section" class="mt-2">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse text-lg">
@@ -135,14 +135,28 @@
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
+        let selectedForecast = '';
+
+        function updateSelectedCard() {
+            forecastPicker.querySelectorAll('.forecast-card').forEach(c => {
+                c.classList.toggle('selected', c.dataset.value === selectedForecast);
+            });
+        }
+
         function populateForecastOptions(data) {
-            forecastPicker.innerHTML = "";
+            forecastPicker.innerHTML = '';
             data.forEach(item => {
                 const dt = new Date(item.dtg);
-                const opt = document.createElement("option");
-                opt.value = dt.toISOString().slice(0,16);
-                opt.textContent = dt.toLocaleDateString("en-GB", {weekday:"short", day:"numeric", month:"short"}) + " " + dt.toLocaleTimeString([], {hour:"2-digit", minute:"2-digit"});
-                forecastPicker.appendChild(opt);
+                const card = document.createElement('div');
+                card.className = 'forecast-card';
+                card.dataset.value = dt.toISOString().slice(0,16);
+                card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
+                card.addEventListener('click', () => {
+                    selectedForecast = card.dataset.value;
+                    updateSelectedCard();
+                    applyForecast();
+                });
+                forecastPicker.appendChild(card);
             });
         }
         const arrowImages = {
@@ -197,8 +211,8 @@
         function updateTideTable() {
             if (!tideData.length) return;
             let selDate = null;
-            if (forecastData.length && forecastPicker.value) {
-                const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+            if (forecastData.length && selectedForecast) {
+                const idx = getNearestForecastIndex(new Date(selectedForecast));
                 const sel = forecastData[idx];
                 if (sel) selDate = new Date(sel.dtg);
             }
@@ -234,10 +248,11 @@
         }
 
         function applyForecast() {
-            const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+            const idx = getNearestForecastIndex(new Date(selectedForecast));
             const item = forecastData[idx];
             if (!item) return;
-            forecastPicker.value = new Date(item.dtg).toISOString().slice(0,16);
+            selectedForecast = new Date(item.dtg).toISOString().slice(0,16);
+            updateSelectedCard();
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
             const dt = new Date(item.dtg);
@@ -264,11 +279,7 @@
         envSelect.addEventListener('change', updateEnvDefinition);
         windDirInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
         windSpeedInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
-        if (forecastPicker) {
-            forecastPicker.addEventListener('change', () => {
-                applyForecast();
-            });
-        }
+
 
         // Initialize on load
         updateWindArrow();
@@ -279,7 +290,8 @@
             reloadBtn.addEventListener('click', () => {
                 if (forecastData.length) {
                     const idx = getNearestForecastIndex(new Date());
-                    forecastPicker.value = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
+                    selectedForecast = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
+                    updateSelectedCard();
                     applyForecast();
                 }
             });
@@ -298,7 +310,8 @@
                         populateForecastOptions(forecastData);
 
                         const idx = getNearestForecastIndex(new Date());
-                        forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        selectedForecast = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        updateSelectedCard();
                         applyForecast();
                     } else if (loading) {
                         loading.textContent = 'Could not load weather data.';

--- a/templates/row.html
+++ b/templates/row.html
@@ -35,7 +35,7 @@
             <form method="post" class="input-form grid gap-4">
                 <div>
                     <label for="forecast-picker" class="block font-medium">Forecast time</label>
-                    <select id="forecast-picker" size="5" class="scroll-wheel w-full"></select>
+                    <div id="forecast-picker" class="date-scroll w-full"></div>
                     <div id="forecast-time" class="text-center text-sm mt-1"></div>
                     <div id="tide-section" class="mt-2 text-sm">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse">
@@ -134,14 +134,28 @@
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
+        let selectedForecast = '';
+
+        function updateSelectedCard() {
+            forecastPicker.querySelectorAll('.forecast-card').forEach(c => {
+                c.classList.toggle('selected', c.dataset.value === selectedForecast);
+            });
+        }
+
         function populateForecastOptions(data) {
-            forecastPicker.innerHTML = "";
+            forecastPicker.innerHTML = '';
             data.forEach(item => {
                 const dt = new Date(item.dtg);
-                const opt = document.createElement("option");
-                opt.value = dt.toISOString().slice(0,16);
-                opt.textContent = dt.toLocaleDateString("en-GB", {weekday:"short", day:"numeric", month:"short"}) + " " + dt.toLocaleTimeString([], {hour:"2-digit", minute:"2-digit"});
-                forecastPicker.appendChild(opt);
+                const card = document.createElement('div');
+                card.className = 'forecast-card';
+                card.dataset.value = dt.toISOString().slice(0,16);
+                card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
+                card.addEventListener('click', () => {
+                    selectedForecast = card.dataset.value;
+                    updateSelectedCard();
+                    applyForecast();
+                });
+                forecastPicker.appendChild(card);
             });
         }
         const arrowImages = {
@@ -196,8 +210,8 @@
         function updateTideTable() {
             if (!tideData.length) return;
             let selDate = null;
-            if (forecastData.length && forecastPicker.value) {
-                const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+            if (forecastData.length && selectedForecast) {
+                const idx = getNearestForecastIndex(new Date(selectedForecast));
                 const sel = forecastData[idx];
                 if (sel) selDate = new Date(sel.dtg);
             }
@@ -233,10 +247,11 @@
         }
 
         function applyForecast() {
-            const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+            const idx = getNearestForecastIndex(new Date(selectedForecast));
             const item = forecastData[idx];
             if (!item) return;
-            forecastPicker.value = new Date(item.dtg).toISOString().slice(0,16);
+            selectedForecast = new Date(item.dtg).toISOString().slice(0,16);
+            updateSelectedCard();
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
             const dt = new Date(item.dtg);
@@ -263,11 +278,7 @@
         envSelect.addEventListener('change', updateEnvDefinition);
         windDirInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
         windSpeedInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
-        if (forecastPicker) {
-            forecastPicker.addEventListener('change', () => {
-                applyForecast();
-            });
-        }
+
 
         // Initialize on load
         updateWindArrow();
@@ -278,7 +289,8 @@
             reloadBtn.addEventListener('click', () => {
                 if (forecastData.length) {
                     const idx = getNearestForecastIndex(new Date());
-                    forecastPicker.value = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
+                    selectedForecast = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
+                    updateSelectedCard();
                     applyForecast();
                 }
             });
@@ -297,7 +309,8 @@
                         populateForecastOptions(forecastData);
 
                         const idx = getNearestForecastIndex(new Date());
-                        forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        selectedForecast = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        updateSelectedCard();
                         applyForecast();
                     } else if (loading) {
                         loading.textContent = 'Could not load weather data.';

--- a/templates/sail.html
+++ b/templates/sail.html
@@ -34,7 +34,7 @@
 
             <form method="post" class="input-form grid gap-4">
                 <label for="forecast-picker" class="block font-medium">Forecast time</label>
-                <select id="forecast-picker" size="5" class="scroll-wheel w-full"></select>
+                <div id="forecast-picker" class="date-scroll w-full"></div>
                 <div id="forecast-time" class="text-center text-1xl sm:text-2xl w-full mt-1"></div>
                     <div id="tide-section" class="mt-2">
                         <table id="tide-table" class="tide-table w-full text-left border-collapse text-lg">
@@ -133,14 +133,28 @@
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
+        let selectedForecast = '';
+
+        function updateSelectedCard() {
+            forecastPicker.querySelectorAll('.forecast-card').forEach(c => {
+                c.classList.toggle('selected', c.dataset.value === selectedForecast);
+            });
+        }
+
         function populateForecastOptions(data) {
-            forecastPicker.innerHTML = "";
+            forecastPicker.innerHTML = '';
             data.forEach(item => {
                 const dt = new Date(item.dtg);
-                const opt = document.createElement("option");
-                opt.value = dt.toISOString().slice(0,16);
-                opt.textContent = dt.toLocaleDateString("en-GB", {weekday:"short", day:"numeric", month:"short"}) + " " + dt.toLocaleTimeString([], {hour:"2-digit", minute:"2-digit"});
-                forecastPicker.appendChild(opt);
+                const card = document.createElement('div');
+                card.className = 'forecast-card';
+                card.dataset.value = dt.toISOString().slice(0,16);
+                card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
+                card.addEventListener('click', () => {
+                    selectedForecast = card.dataset.value;
+                    updateSelectedCard();
+                    applyForecast();
+                });
+                forecastPicker.appendChild(card);
             });
         }
         const arrowImages = {
@@ -195,8 +209,8 @@
         function updateTideTable() {
             if (!tideData.length) return;
             let selDate = null;
-            if (forecastData.length && forecastPicker.value) {
-                const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+            if (forecastData.length && selectedForecast) {
+                const idx = getNearestForecastIndex(new Date(selectedForecast));
                 const sel = forecastData[idx];
                 if (sel) selDate = new Date(sel.dtg);
             }
@@ -232,10 +246,11 @@
         }
 
         function applyForecast() {
-            const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+            const idx = getNearestForecastIndex(new Date(selectedForecast));
             const item = forecastData[idx];
             if (!item) return;
-            forecastPicker.value = new Date(item.dtg).toISOString().slice(0,16);
+            selectedForecast = new Date(item.dtg).toISOString().slice(0,16);
+            updateSelectedCard();
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
             const dt = new Date(item.dtg);
@@ -262,11 +277,7 @@
         envSelect.addEventListener('change', updateEnvDefinition);
         windDirInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
         windSpeedInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
-        if (forecastPicker) {
-            forecastPicker.addEventListener('change', () => {
-                applyForecast();
-            });
-        }
+
 
         // Initialize on load
         updateWindArrow();
@@ -277,7 +288,8 @@
             reloadBtn.addEventListener('click', () => {
                 if (forecastData.length) {
                     const idx = getNearestForecastIndex(new Date());
-                    forecastPicker.value = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
+                    selectedForecast = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
+                    updateSelectedCard();
                     applyForecast();
                 }
             });
@@ -296,7 +308,8 @@
                         populateForecastOptions(forecastData);
 
                         const idx = getNearestForecastIndex(new Date());
-                        forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        selectedForecast = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        updateSelectedCard();
                         applyForecast();
                     } else if (loading) {
                         loading.textContent = 'Could not load weather data.';

--- a/templates/swim.html
+++ b/templates/swim.html
@@ -86,7 +86,7 @@
                 </div>
                 <br>   
                 <label class="block font-medium sm:text-sm">Change date:</label>
-                <select id="forecast-picker" size="5" class="scroll-wheel w-full"></select>
+                <div id="forecast-picker" class="date-scroll w-full"></div>
             </form>
         </div>
         <div class="mt-4 text-center">
@@ -104,14 +104,28 @@
         const forecastTime = document.getElementById('forecast-time');
         let forecastData = [];
         let tideData = [];
+        let selectedForecast = '';
+
+        function updateSelectedCard() {
+            forecastPicker.querySelectorAll('.forecast-card').forEach(c => {
+                c.classList.toggle('selected', c.dataset.value === selectedForecast);
+            });
+        }
+
         function populateForecastOptions(data) {
-            forecastPicker.innerHTML = "";
+            forecastPicker.innerHTML = '';
             data.forEach(item => {
                 const dt = new Date(item.dtg);
-                const opt = document.createElement("option");
-                opt.value = dt.toISOString().slice(0,16);
-                opt.textContent = dt.toLocaleDateString("en-GB", {weekday:"short", day:"numeric", month:"short"}) + " " + dt.toLocaleTimeString([], {hour:"2-digit", minute:"2-digit"});
-                forecastPicker.appendChild(opt);
+                const card = document.createElement('div');
+                card.className = 'forecast-card';
+                card.dataset.value = dt.toISOString().slice(0,16);
+                card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
+                card.addEventListener('click', () => {
+                    selectedForecast = card.dataset.value;
+                    updateSelectedCard();
+                    applyForecast();
+                });
+                forecastPicker.appendChild(card);
             });
         }
         const waterQualityEl = document.getElementById('water_quality');
@@ -163,8 +177,8 @@
         function updateTideTable() {
             if (!tideData.length) return;
             let selDate = null;
-            if (forecastData.length && forecastPicker.value) {
-                const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+            if (forecastData.length && selectedForecast) {
+                const idx = getNearestForecastIndex(new Date(selectedForecast));
                 const sel = forecastData[idx];
                 if (sel) selDate = new Date(sel.dtg);
             }
@@ -257,10 +271,11 @@
         }
 
         function applyForecast() {
-            const idx = getNearestForecastIndex(new Date(forecastPicker.value));
+            const idx = getNearestForecastIndex(new Date(selectedForecast));
             const item = forecastData[idx];
             if (!item) return;
-            forecastPicker.value = new Date(item.dtg).toISOString().slice(0,16);
+            selectedForecast = new Date(item.dtg).toISOString().slice(0,16);
+            updateSelectedCard();
             windSpeedInput.textContent = item.speed;
             windDirInput.textContent = item.direction;
             const airEl = document.getElementById('air_temperature');
@@ -295,11 +310,7 @@
             windArrow.style.transform = `rotate(${angle - 180}deg)`;
         }
 
-        if (forecastPicker) {
-            forecastPicker.addEventListener('change', () => {
-                applyForecast();
-            });
-        }
+
 
         // Initialize on load
         updateWindArrow();
@@ -321,7 +332,8 @@
                         forecastData = fData;
                           populateForecastOptions(forecastData);
                         const idx = getNearestForecastIndex(new Date());
-                        forecastPicker.value = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        selectedForecast = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        updateSelectedCard();
                         applyForecast();
                     } else if (loading) {
                         loading.textContent = 'Could not load weather data.';


### PR DESCRIPTION
## Summary
- implement `.date-scroll` and `.forecast-card` styles
- replace scroll wheel with horizontal card slider on each page
- adjust JS logic to highlight selected card and use `selectedForecast`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68625f37817c8323bc60cb7e588910ab