### PR TITLE
Fix forecast picker selection

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -111,6 +111,7 @@ input[type="range"]::-moz-range-thumb {
     overflow-x: auto;
     gap: 0.5rem;
     padding: 4px 0;
+    scroll-snap-type: x mandatory;
 }
 .forecast-card {
     flex: 0 0 auto;
@@ -121,6 +122,7 @@ input[type="range"]::-moz-range-thumb {
     padding: 4px 8px;
     cursor: pointer;
     user-select: none;
+    scroll-snap-align: center;
 }
 .forecast-card.selected {
     background-color: #bfdbfe;

--- a/templates/index.html
+++ b/templates/index.html
@@ -76,7 +76,7 @@
                 const dt = new Date(item.dtg);
                 const card = document.createElement('div');
                 card.className = 'forecast-card';
-                card.dataset.value = dt.toISOString().slice(0,16);
+                card.dataset.value = item.dtg;
                 card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
@@ -85,6 +85,25 @@
                 });
                 forecastPicker.appendChild(card);
             });
+        }
+
+        function handleScroll() {
+            const center = forecastPicker.scrollLeft + forecastPicker.clientWidth / 2;
+            let nearest = null;
+            let dist = Infinity;
+            forecastPicker.querySelectorAll('.forecast-card').forEach(card => {
+                const cardCenter = card.offsetLeft + card.offsetWidth / 2;
+                const d = Math.abs(cardCenter - center);
+                if (d < dist) {
+                    dist = d;
+                    nearest = card;
+                }
+            });
+            if (nearest && nearest.dataset.value !== selectedForecast) {
+                selectedForecast = nearest.dataset.value;
+                updateSelectedCard();
+                applyForecast();
+            }
         }
         const arrowImages = {
             1: "http://quacksolution.com/force1.png",
@@ -180,7 +199,7 @@
             const idx = getNearestForecastIndex(new Date(selectedForecast));
             const item = forecastData[idx];
             if (!item) return;
-            selectedForecast = new Date(item.dtg).toISOString().slice(0,16);
+            selectedForecast = item.dtg;
             updateSelectedCard();
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
@@ -208,6 +227,9 @@
         if (envSelect) envSelect.addEventListener('change', updateEnvDefinition);
         if (windDirInput.addEventListener) windDirInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
         if (windSpeedInput.addEventListener) windSpeedInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
+        if (forecastPicker) forecastPicker.addEventListener('scroll', () => {
+            window.requestAnimationFrame(handleScroll);
+        });
 
 
         // Initialize on load
@@ -219,7 +241,7 @@
             reloadBtn.addEventListener('click', () => {
                 if (forecastData.length) {
                     const idx = getNearestForecastIndex(new Date());
-                    selectedForecast = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
+                    selectedForecast = forecastData[idx].dtg;
                     updateSelectedCard();
                     applyForecast();
                 }
@@ -239,7 +261,7 @@
                         populateForecastOptions(forecastData);
 
                         const idx = getNearestForecastIndex(new Date());
-                        selectedForecast = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        selectedForecast = fData[idx].dtg;
                         updateSelectedCard();
                         applyForecast();
                     } else if (loading) {

--- a/templates/paddle.html
+++ b/templates/paddle.html
@@ -149,7 +149,7 @@
                 const dt = new Date(item.dtg);
                 const card = document.createElement('div');
                 card.className = 'forecast-card';
-                card.dataset.value = dt.toISOString().slice(0,16);
+                card.dataset.value = item.dtg;
                 card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
@@ -158,6 +158,25 @@
                 });
                 forecastPicker.appendChild(card);
             });
+        }
+
+        function handleScroll() {
+            const center = forecastPicker.scrollLeft + forecastPicker.clientWidth / 2;
+            let nearest = null;
+            let dist = Infinity;
+            forecastPicker.querySelectorAll('.forecast-card').forEach(card => {
+                const cardCenter = card.offsetLeft + card.offsetWidth / 2;
+                const d = Math.abs(cardCenter - center);
+                if (d < dist) {
+                    dist = d;
+                    nearest = card;
+                }
+            });
+            if (nearest && nearest.dataset.value !== selectedForecast) {
+                selectedForecast = nearest.dataset.value;
+                updateSelectedCard();
+                applyForecast();
+            }
         }
         const arrowImages = {
             1: "http://quacksolution.com/force1.png",
@@ -251,7 +270,7 @@
             const idx = getNearestForecastIndex(new Date(selectedForecast));
             const item = forecastData[idx];
             if (!item) return;
-            selectedForecast = new Date(item.dtg).toISOString().slice(0,16);
+            selectedForecast = item.dtg;
             updateSelectedCard();
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
@@ -279,6 +298,9 @@
         envSelect.addEventListener('change', updateEnvDefinition);
         windDirInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
         windSpeedInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
+        forecastPicker.addEventListener('scroll', () => {
+            window.requestAnimationFrame(handleScroll);
+        });
 
 
         // Initialize on load
@@ -290,7 +312,7 @@
             reloadBtn.addEventListener('click', () => {
                 if (forecastData.length) {
                     const idx = getNearestForecastIndex(new Date());
-                    selectedForecast = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
+                    selectedForecast = forecastData[idx].dtg;
                     updateSelectedCard();
                     applyForecast();
                 }
@@ -310,7 +332,7 @@
                         populateForecastOptions(forecastData);
 
                         const idx = getNearestForecastIndex(new Date());
-                        selectedForecast = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        selectedForecast = fData[idx].dtg;
                         updateSelectedCard();
                         applyForecast();
                     } else if (loading) {

--- a/templates/row.html
+++ b/templates/row.html
@@ -148,7 +148,7 @@
                 const dt = new Date(item.dtg);
                 const card = document.createElement('div');
                 card.className = 'forecast-card';
-                card.dataset.value = dt.toISOString().slice(0,16);
+                card.dataset.value = item.dtg;
                 card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
@@ -157,6 +157,25 @@
                 });
                 forecastPicker.appendChild(card);
             });
+        }
+
+        function handleScroll() {
+            const center = forecastPicker.scrollLeft + forecastPicker.clientWidth / 2;
+            let nearest = null;
+            let dist = Infinity;
+            forecastPicker.querySelectorAll('.forecast-card').forEach(card => {
+                const cardCenter = card.offsetLeft + card.offsetWidth / 2;
+                const d = Math.abs(cardCenter - center);
+                if (d < dist) {
+                    dist = d;
+                    nearest = card;
+                }
+            });
+            if (nearest && nearest.dataset.value !== selectedForecast) {
+                selectedForecast = nearest.dataset.value;
+                updateSelectedCard();
+                applyForecast();
+            }
         }
         const arrowImages = {
             1: "http://quacksolution.com/force1.png",
@@ -250,7 +269,7 @@
             const idx = getNearestForecastIndex(new Date(selectedForecast));
             const item = forecastData[idx];
             if (!item) return;
-            selectedForecast = new Date(item.dtg).toISOString().slice(0,16);
+            selectedForecast = item.dtg;
             updateSelectedCard();
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
@@ -278,6 +297,9 @@
         envSelect.addEventListener('change', updateEnvDefinition);
         windDirInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
         windSpeedInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
+        forecastPicker.addEventListener('scroll', () => {
+            window.requestAnimationFrame(handleScroll);
+        });
 
 
         // Initialize on load
@@ -289,7 +311,7 @@
             reloadBtn.addEventListener('click', () => {
                 if (forecastData.length) {
                     const idx = getNearestForecastIndex(new Date());
-                    selectedForecast = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
+                    selectedForecast = forecastData[idx].dtg;
                     updateSelectedCard();
                     applyForecast();
                 }
@@ -309,7 +331,7 @@
                         populateForecastOptions(forecastData);
 
                         const idx = getNearestForecastIndex(new Date());
-                        selectedForecast = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        selectedForecast = fData[idx].dtg;
                         updateSelectedCard();
                         applyForecast();
                     } else if (loading) {

--- a/templates/sail.html
+++ b/templates/sail.html
@@ -147,7 +147,7 @@
                 const dt = new Date(item.dtg);
                 const card = document.createElement('div');
                 card.className = 'forecast-card';
-                card.dataset.value = dt.toISOString().slice(0,16);
+                card.dataset.value = item.dtg;
                 card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
@@ -156,6 +156,25 @@
                 });
                 forecastPicker.appendChild(card);
             });
+        }
+
+        function handleScroll() {
+            const center = forecastPicker.scrollLeft + forecastPicker.clientWidth / 2;
+            let nearest = null;
+            let dist = Infinity;
+            forecastPicker.querySelectorAll('.forecast-card').forEach(card => {
+                const cardCenter = card.offsetLeft + card.offsetWidth / 2;
+                const d = Math.abs(cardCenter - center);
+                if (d < dist) {
+                    dist = d;
+                    nearest = card;
+                }
+            });
+            if (nearest && nearest.dataset.value !== selectedForecast) {
+                selectedForecast = nearest.dataset.value;
+                updateSelectedCard();
+                applyForecast();
+            }
         }
         const arrowImages = {
             1: "http://quacksolution.com/force1.png",
@@ -249,7 +268,7 @@
             const idx = getNearestForecastIndex(new Date(selectedForecast));
             const item = forecastData[idx];
             if (!item) return;
-            selectedForecast = new Date(item.dtg).toISOString().slice(0,16);
+            selectedForecast = item.dtg;
             updateSelectedCard();
             windSpeedInput.value = item.speed;
             windDirInput.value = item.direction;
@@ -277,6 +296,9 @@
         envSelect.addEventListener('change', updateEnvDefinition);
         windDirInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
         windSpeedInput.addEventListener('input', () => { updateWindArrow(); updateCurrentConditions(); });
+        forecastPicker.addEventListener('scroll', () => {
+            window.requestAnimationFrame(handleScroll);
+        });
 
 
         // Initialize on load
@@ -288,7 +310,7 @@
             reloadBtn.addEventListener('click', () => {
                 if (forecastData.length) {
                     const idx = getNearestForecastIndex(new Date());
-                    selectedForecast = new Date(forecastData[idx].dtg).toISOString().slice(0,16);
+                    selectedForecast = forecastData[idx].dtg;
                     updateSelectedCard();
                     applyForecast();
                 }
@@ -308,7 +330,7 @@
                         populateForecastOptions(forecastData);
 
                         const idx = getNearestForecastIndex(new Date());
-                        selectedForecast = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        selectedForecast = fData[idx].dtg;
                         updateSelectedCard();
                         applyForecast();
                     } else if (loading) {

--- a/templates/swim.html
+++ b/templates/swim.html
@@ -118,7 +118,7 @@
                 const dt = new Date(item.dtg);
                 const card = document.createElement('div');
                 card.className = 'forecast-card';
-                card.dataset.value = dt.toISOString().slice(0,16);
+                card.dataset.value = item.dtg;
                 card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
@@ -127,6 +127,25 @@
                 });
                 forecastPicker.appendChild(card);
             });
+        }
+
+        function handleScroll() {
+            const center = forecastPicker.scrollLeft + forecastPicker.clientWidth / 2;
+            let nearest = null;
+            let dist = Infinity;
+            forecastPicker.querySelectorAll('.forecast-card').forEach(card => {
+                const cardCenter = card.offsetLeft + card.offsetWidth / 2;
+                const d = Math.abs(cardCenter - center);
+                if (d < dist) {
+                    dist = d;
+                    nearest = card;
+                }
+            });
+            if (nearest && nearest.dataset.value !== selectedForecast) {
+                selectedForecast = nearest.dataset.value;
+                updateSelectedCard();
+                applyForecast();
+            }
         }
         const waterQualityEl = document.getElementById('water_quality');
         let seaTemps = JSON.parse(localStorage.getItem('seaTemps') || 'null');
@@ -274,7 +293,7 @@
             const idx = getNearestForecastIndex(new Date(selectedForecast));
             const item = forecastData[idx];
             if (!item) return;
-            selectedForecast = new Date(item.dtg).toISOString().slice(0,16);
+            selectedForecast = item.dtg;
             updateSelectedCard();
             windSpeedInput.textContent = item.speed;
             windDirInput.textContent = item.direction;
@@ -316,6 +335,9 @@
         updateWindArrow();
         updateCurrentConditions();
         applyColorScales();
+        forecastPicker.addEventListener('scroll', () => {
+            window.requestAnimationFrame(handleScroll);
+        });
 
         window.addEventListener('DOMContentLoaded', () => {
             const loading = document.getElementById('loading-message');
@@ -332,7 +354,7 @@
                         forecastData = fData;
                           populateForecastOptions(forecastData);
                         const idx = getNearestForecastIndex(new Date());
-                        selectedForecast = new Date(fData[idx].dtg).toISOString().slice(0,16);
+                        selectedForecast = fData[idx].dtg;
                         updateSelectedCard();
                         applyForecast();
                     } else if (loading) {


### PR DESCRIPTION
## Summary
- add scroll snap styles for smoother forecast picker
- auto-select the forecast at the scroll center
- keep time zone info when storing forecast timestamps

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686264ade47c83239c0a231b0cede896