### PR TITLE
Improve forecast date cards and fix layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -123,7 +123,21 @@ input[type="range"]::-moz-range-thumb {
     cursor: pointer;
     user-select: none;
     scroll-snap-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
 }
 .forecast-card.selected {
     background-color: #bfdbfe;
+}
+
+.forecast-card .date-day {
+    font-size: 1.25em;
+    font-weight: bold;
+}
+
+.forecast-card .date-month,
+.forecast-card .date-time {
+    font-size: 0.75em;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -77,7 +77,10 @@
                 const card = document.createElement('div');
                 card.className = 'forecast-card';
                 card.dataset.value = item.dtg;
-                card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
+                const month = dt.toLocaleDateString('en-GB', { month: 'short' });
+                const day = dt.getDate();
+                const time = dt.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false });
+                card.innerHTML = `<div class="date-month">${month}</div><div class="date-day">${day}</div><div class="date-time">${time}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();

--- a/templates/paddle.html
+++ b/templates/paddle.html
@@ -46,7 +46,6 @@
                         </table>
                     </div>
                 </div>
-                </div>
 
                 <div>
                     <label for="location" class="block font-medium">Location</label>
@@ -150,7 +149,10 @@
                 const card = document.createElement('div');
                 card.className = 'forecast-card';
                 card.dataset.value = item.dtg;
-                card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
+                const month = dt.toLocaleDateString('en-GB', { month: 'short' });
+                const day = dt.getDate();
+                const time = dt.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false });
+                card.innerHTML = `<div class="date-month">${month}</div><div class="date-day">${day}</div><div class="date-time">${time}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();

--- a/templates/row.html
+++ b/templates/row.html
@@ -149,7 +149,10 @@
                 const card = document.createElement('div');
                 card.className = 'forecast-card';
                 card.dataset.value = item.dtg;
-                card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
+                const month = dt.toLocaleDateString('en-GB', { month: 'short' });
+                const day = dt.getDate();
+                const time = dt.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false });
+                card.innerHTML = `<div class="date-month">${month}</div><div class="date-day">${day}</div><div class="date-time">${time}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();

--- a/templates/sail.html
+++ b/templates/sail.html
@@ -36,14 +36,13 @@
                 <label for="forecast-picker" class="block font-medium">Forecast time</label>
                 <div id="forecast-picker" class="date-scroll w-full"></div>
                 <div id="forecast-time" class="text-center text-1xl sm:text-2xl w-full mt-1"></div>
-                    <div id="tide-section" class="mt-2">
-                        <table id="tide-table" class="tide-table w-full text-left border-collapse text-lg">
-                            <thead>
-                                <tr><th class="px-1">Time</th><th class="px-1">Tide</th></tr>
-                            </thead>
-                            <tbody></tbody>
-                        </table>
-                    </div>
+                <div id="tide-section" class="mt-2">
+                    <table id="tide-table" class="tide-table w-full text-left border-collapse text-lg">
+                        <thead>
+                            <tr><th class="px-1">Time</th><th class="px-1">Tide</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
                 </div>
 
                 <div>
@@ -148,7 +147,10 @@
                 const card = document.createElement('div');
                 card.className = 'forecast-card';
                 card.dataset.value = item.dtg;
-                card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
+                const month = dt.toLocaleDateString('en-GB', { month: 'short' });
+                const day = dt.getDate();
+                const time = dt.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false });
+                card.innerHTML = `<div class="date-month">${month}</div><div class="date-day">${day}</div><div class="date-time">${time}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();

--- a/templates/swim.html
+++ b/templates/swim.html
@@ -119,7 +119,10 @@
                 const card = document.createElement('div');
                 card.className = 'forecast-card';
                 card.dataset.value = item.dtg;
-                card.textContent = dt.toLocaleDateString('en-GB', {weekday:'short', day:'numeric', month:'short'});
+                const month = dt.toLocaleDateString('en-GB', { month: 'short' });
+                const day = dt.getDate();
+                const time = dt.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false });
+                card.innerHTML = `<div class="date-month">${month}</div><div class="date-day">${day}</div><div class="date-time">${time}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();


### PR DESCRIPTION
## Summary
- style forecast cards with vertical stacked month/day/time
- display month, day and time inside cards across all pages
- fix extra closing divs spilling content

## Testing
- `python -m py_compile app.py`
- `pip install flask`

------
https://chatgpt.com/codex/tasks/task_e_68626a33da088323885ece6ec68db468