### PR TITLE
Improve forecast date cards and layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -85,6 +85,10 @@ body {
     font-size: 2em;
 }
 
+#tide-section {
+    overflow-x: auto;
+}
+
 input[type="range"]::-webkit-slider-thumb {
     width: 35px;
     height: 35px;
@@ -132,12 +136,12 @@ input[type="range"]::-moz-range-thumb {
     background-color: #bfdbfe;
 }
 
-.forecast-card .date-day {
+.forecast-card .date-month-day {
     font-size: 1.25em;
     font-weight: bold;
 }
 
-.forecast-card .date-month,
-.forecast-card .date-time {
+.forecast-card .date-time,
+.forecast-card .date-weekday {
     font-size: 0.75em;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,8 +79,9 @@
                 card.dataset.value = item.dtg;
                 const month = dt.toLocaleDateString('en-GB', { month: 'short' });
                 const day = dt.getDate();
-                const time = dt.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false });
-                card.innerHTML = `<div class="date-month">${month}</div><div class="date-day">${day}</div><div class="date-time">${time}</div>`;
+                const time = dt.toLocaleTimeString('en-GB', { hour: 'numeric', hour12: true }).replace(/\s+/g,'').toLowerCase();
+                const weekday = dt.toLocaleDateString('en-GB', { weekday: 'short' });
+                card.innerHTML = `<div class="date-month-day">${month} ${day}</div><div class="date-time">${time}</div><div class="date-weekday">${weekday}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();

--- a/templates/paddle.html
+++ b/templates/paddle.html
@@ -151,8 +151,9 @@
                 card.dataset.value = item.dtg;
                 const month = dt.toLocaleDateString('en-GB', { month: 'short' });
                 const day = dt.getDate();
-                const time = dt.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false });
-                card.innerHTML = `<div class="date-month">${month}</div><div class="date-day">${day}</div><div class="date-time">${time}</div>`;
+                const time = dt.toLocaleTimeString('en-GB', { hour: 'numeric', hour12: true }).replace(/\s+/g,'').toLowerCase();
+                const weekday = dt.toLocaleDateString('en-GB', { weekday: 'short' });
+                card.innerHTML = `<div class="date-month-day">${month} ${day}</div><div class="date-time">${time}</div><div class="date-weekday">${weekday}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();

--- a/templates/row.html
+++ b/templates/row.html
@@ -151,8 +151,9 @@
                 card.dataset.value = item.dtg;
                 const month = dt.toLocaleDateString('en-GB', { month: 'short' });
                 const day = dt.getDate();
-                const time = dt.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false });
-                card.innerHTML = `<div class="date-month">${month}</div><div class="date-day">${day}</div><div class="date-time">${time}</div>`;
+                const time = dt.toLocaleTimeString('en-GB', { hour: 'numeric', hour12: true }).replace(/\s+/g,'').toLowerCase();
+                const weekday = dt.toLocaleDateString('en-GB', { weekday: 'short' });
+                card.innerHTML = `<div class="date-month-day">${month} ${day}</div><div class="date-time">${time}</div><div class="date-weekday">${weekday}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();

--- a/templates/sail.html
+++ b/templates/sail.html
@@ -149,8 +149,9 @@
                 card.dataset.value = item.dtg;
                 const month = dt.toLocaleDateString('en-GB', { month: 'short' });
                 const day = dt.getDate();
-                const time = dt.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false });
-                card.innerHTML = `<div class="date-month">${month}</div><div class="date-day">${day}</div><div class="date-time">${time}</div>`;
+                const time = dt.toLocaleTimeString('en-GB', { hour: 'numeric', hour12: true }).replace(/\s+/g,'').toLowerCase();
+                const weekday = dt.toLocaleDateString('en-GB', { weekday: 'short' });
+                card.innerHTML = `<div class="date-month-day">${month} ${day}</div><div class="date-time">${time}</div><div class="date-weekday">${weekday}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();

--- a/templates/swim.html
+++ b/templates/swim.html
@@ -121,8 +121,9 @@
                 card.dataset.value = item.dtg;
                 const month = dt.toLocaleDateString('en-GB', { month: 'short' });
                 const day = dt.getDate();
-                const time = dt.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false });
-                card.innerHTML = `<div class="date-month">${month}</div><div class="date-day">${day}</div><div class="date-time">${time}</div>`;
+                const time = dt.toLocaleTimeString('en-GB', { hour: 'numeric', hour12: true }).replace(/\s+/g,'').toLowerCase();
+                const weekday = dt.toLocaleDateString('en-GB', { weekday: 'short' });
+                card.innerHTML = `<div class="date-month-day">${month} ${day}</div><div class="date-time">${time}</div><div class="date-weekday">${weekday}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();


### PR DESCRIPTION
## Summary
- display forecast cards as `Month Day`, `Time`, `Weekday`
- keep tide table within form wrapper

## Testing
- `python -m py_compile app.py`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_68626fe609508323a191c8c011c85a1e