### PR TITLE
Swap time and date order in forecast cards

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -219,7 +219,7 @@
                 const day = dt.getDate();
                 const time = dt.toLocaleTimeString('en-GB', { hour: 'numeric', hour12: true }).replace(/\s+/g,'').toLowerCase();
                 const weekday = dt.toLocaleDateString('en-GB', { weekday: 'short' });
-                card.innerHTML = `<div class="date-month-day">${month} ${day}</div><div class="date-time">${time}</div><div class="date-weekday">${weekday}</div>`;
+                card.innerHTML = `<div class="date-time">${time}</div><div class="date-month-day">${month} ${day}</div><div class="date-weekday">${weekday}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();

--- a/templates/paddle.html
+++ b/templates/paddle.html
@@ -153,7 +153,7 @@
                 const day = dt.getDate();
                 const time = dt.toLocaleTimeString('en-GB', { hour: 'numeric', hour12: true }).replace(/\s+/g,'').toLowerCase();
                 const weekday = dt.toLocaleDateString('en-GB', { weekday: 'short' });
-                card.innerHTML = `<div class="date-month-day">${month} ${day}</div><div class="date-time">${time}</div><div class="date-weekday">${weekday}</div>`;
+                card.innerHTML = `<div class="date-time">${time}</div><div class="date-month-day">${month} ${day}</div><div class="date-weekday">${weekday}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();

--- a/templates/row.html
+++ b/templates/row.html
@@ -122,7 +122,7 @@
                 const day = dt.getDate();
                 const time = dt.toLocaleTimeString('en-GB', { hour: 'numeric', hour12: true }).replace(/\s+/g,'').toLowerCase();
                 const weekday = dt.toLocaleDateString('en-GB', { weekday: 'short' });
-                card.innerHTML = `<div class="date-month-day">${month} ${day}</div><div class="date-time">${time}</div><div class="date-weekday">${weekday}</div>`;
+                card.innerHTML = `<div class="date-time">${time}</div><div class="date-month-day">${month} ${day}</div><div class="date-weekday">${weekday}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();

--- a/templates/sail.html
+++ b/templates/sail.html
@@ -122,7 +122,7 @@
                 const day = dt.getDate();
                 const time = dt.toLocaleTimeString('en-GB', { hour: 'numeric', hour12: true }).replace(/\s+/g,'').toLowerCase();
                 const weekday = dt.toLocaleDateString('en-GB', { weekday: 'short' });
-                card.innerHTML = `<div class="date-month-day">${month} ${day}</div><div class="date-time">${time}</div><div class="date-weekday">${weekday}</div>`;
+                card.innerHTML = `<div class="date-time">${time}</div><div class="date-month-day">${month} ${day}</div><div class="date-weekday">${weekday}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();

--- a/templates/swim.html
+++ b/templates/swim.html
@@ -122,7 +122,7 @@
                 const day = dt.getDate();
                 const time = dt.toLocaleTimeString('en-GB', { hour: 'numeric', hour12: true }).replace(/\s+/g,'').toLowerCase();
                 const weekday = dt.toLocaleDateString('en-GB', { weekday: 'short' });
-                card.innerHTML = `<div class="date-month-day">${month} ${day}</div><div class="date-time">${time}</div><div class="date-weekday">${weekday}</div>`;
+                card.innerHTML = `<div class="date-time">${time}</div><div class="date-month-day">${month} ${day}</div><div class="date-weekday">${weekday}</div>`;
                 card.addEventListener('click', () => {
                     selectedForecast = card.dataset.value;
                     updateSelectedCard();


### PR DESCRIPTION
## Summary
- switch order of time and date in all forecast cards so the time appears first

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686515da4e448323968018dbd91e57b0